### PR TITLE
Nicer error when fail to connect to gandalf

### DIFF
--- a/client.go
+++ b/client.go
@@ -52,7 +52,7 @@ func (c *Client) doRequest(method, path string, body io.Reader) (*http.Response,
 	}
 	response, err := (&http.Client{}).Do(request)
 	if err != nil {
-		return nil, errors.New("Failed to connect to Gandalf server, it's probably down.")
+		return nil, fmt.Errorf("Failed to connect to Gandalf server (%s) - %s", c.Endpoint, err.Error())
 	}
 	return response, nil
 }

--- a/client_test.go
+++ b/client_test.go
@@ -47,7 +47,7 @@ func (s *S) TestDoRequestConnectionError(c *C) {
 	response, err := client.doRequest("GET", "/", nil)
 	c.Assert(response, IsNil)
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "Failed to connect to Gandalf server, it's probably down.")
+	c.Assert(err.Error(), Equals, "Failed to connect to Gandalf server (http://127.0.0.1:747399) - Get http://127.0.0.1:747399/: dial tcp: invalid port 747399")
 }
 
 func (s *S) TestPost(c *C) {
@@ -77,7 +77,7 @@ func (s *S) TestPostConnectionFailure(c *C) {
 	client := Client{Endpoint: "http://127.0.0.1:747399"}
 	err := client.post(nil, "/")
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "Failed to connect to Gandalf server, it's probably down.")
+	c.Assert(err.Error(), Equals, "Failed to connect to Gandalf server (http://127.0.0.1:747399) - Post http://127.0.0.1:747399/: dial tcp: invalid port 747399")
 }
 
 func (s *S) TestPostMarshalingFailure(c *C) {
@@ -105,7 +105,7 @@ func (s *S) TestDeleteWithConnectionError(c *C) {
 	client := Client{Endpoint: "http://127.0.0.1:747399"}
 	err := client.delete(nil, "/users/something")
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "Failed to connect to Gandalf server, it's probably down.")
+	c.Assert(err.Error(), Equals, "Failed to connect to Gandalf server (http://127.0.0.1:747399) - dial tcp: invalid port 747399")
 }
 
 func (s *S) TestDeleteWithMarshalingError(c *C) {
@@ -476,4 +476,5 @@ func (s *S) TestHealthCheckOnHTTPError(c *C) {
 	client := Client{Endpoint: ts.URL}
 	_, err := client.GetHealthCheck()
 	c.Assert(err, NotNil)
-	c.Assert(err, ErrorMatches, "^Error performing requested operation\n$")}
+	c.Assert(err, ErrorMatches, "^Error performing requested operation\n$")
+}


### PR DESCRIPTION
Before:

```
$ http http://127.0.0.1:8080/healthcheck/ Authorization:"Bearer $(<~/.tsuru_token)"
HTTP/1.1 500 Internal Server Error
Content-Type: text/plain; charset=utf-8
Date: Wed, 31 Dec 2014 17:42:14 GMT
Supported-Crane: 0.6.0
Supported-Tsuru: 0.14.0
Supported-Tsuru-Admin: 0.8.1
Transfer-Encoding: chunked

Failed to connect to Gandalf server, it's probably down.
```

After:

```
$ http http://127.0.0.1:8080/healthcheck/ Authorization:"Bearer $(<~/.tsuru_token)"
HTTP/1.1 500 Internal Server Error
Content-Type: text/plain; charset=utf-8
Date: Wed, 31 Dec 2014 17:47:00 GMT
Supported-Crane: 0.6.0
Supported-Tsuru: 0.14.0
Supported-Tsuru-Admin: 0.8.1
Transfer-Encoding: chunked

Failed to connect to Gandalf server (http://127.0.0.1:8000) - Get http://127.0.0.1:8000/healthcheck: dial tcp 127.0.0.1:8000: connection refused
```
